### PR TITLE
Fix for firefox matrix based scale transforms

### DIFF
--- a/jquery-animate-css-rotate-scale.js
+++ b/jquery-animate-css-rotate-scale.js
@@ -66,7 +66,7 @@
         }
         
         //is this a scale transform?
-        if(style.match(/scale\(([^)]+)\)/)){
+        if(style.match(/none|scale\([^)]*\)/) || style == undefined || style == ''){
            $(this).css('transform', style.replace(/none|scale\([^)]*\)/, '') + 'scale(' + val + ')');
         }
         

--- a/jquery-animate-css-rotate-scale.js
+++ b/jquery-animate-css-rotate-scale.js
@@ -53,16 +53,27 @@
                 if (m && m[1])
                 {
                     return m[1];
+                } else {
+                    var m = style.match(/matrix\(([^)]+)\)/);
+                    if (m && m[1]) {
+                        var matrixArray = m[1].split(',');
+                        return matrixArray[0];
+                    }
                 }
             }
             
             return 1;
         }
         
-        $(this).css(
-            'transform',
-            style.replace(/none|scale\([^)]*\)/, '') + 'scale(' + val + ')'
-        );
+        //is this a scale transform?
+        if(style.match(/scale\(([^)]+)\)/)){
+           $(this).css('transform', style.replace(/none|scale\([^)]*\)/, '') + 'scale(' + val + ')');
+        }
+        
+        //is this a matrix transform?
+        if(style.match(/matrix\(([^)]+)\)/)){
+           $(this).css('transform', style.replace(/none|matrix\([^)]*\)/, '') + 'matrix(' + val + ', 0, 0, ' + val + ', 0, 0)');
+        }
         
         return this;
     }


### PR DESCRIPTION
Latest firefox versions return scaling style as a transformation matrix, this patch checks for that condition and makes the changes necessary for those transformations to work
